### PR TITLE
[Feature] 서버 통신 메소드 및 데이터 모델 작성 (Announcement 기준)

### DIFF
--- a/KeKi.xcodeproj/project.pbxproj
+++ b/KeKi.xcodeproj/project.pbxproj
@@ -88,6 +88,9 @@
 		A2E015102992A32B00EBACF0 /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E0150F2992A32B00EBACF0 /* HomeCollectionViewCell.swift */; };
 		A2E015122992A35700EBACF0 /* HomeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E015112992A35700EBACF0 /* HomeTableViewCell.swift */; };
 		A2E015162992A66600EBACF0 /* UIDevice+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E015152992A66600EBACF0 /* UIDevice+.swift */; };
+		A2E0151B29933AF700EBACF0 /* BasicModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E0151929933AF700EBACF0 /* BasicModel.swift */; };
+		A2E0151C29933AF700EBACF0 /* AnnouncementModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E0151A29933AF700EBACF0 /* AnnouncementModel.swift */; };
+		A2E0151E29933B0100EBACF0 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E0151D29933B0100EBACF0 /* APIManager.swift */; };
 		A2F6075529890F8C00F4F3DD /* FeedImgsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2F6075329890F8C00F4F3DD /* FeedImgsCell.swift */; };
 		A2F6075629890F8C00F4F3DD /* FeedImgsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A2F6075429890F8C00F4F3DD /* FeedImgsCell.xib */; };
 		A2F607592989632700F4F3DD /* ProductDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2F607582989632700F4F3DD /* ProductDetail.storyboard */; };
@@ -182,6 +185,9 @@
 		A2E0150F2992A32B00EBACF0 /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		A2E015112992A35700EBACF0 /* HomeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeTableViewCell.swift; sourceTree = "<group>"; };
 		A2E015152992A66600EBACF0 /* UIDevice+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+.swift"; sourceTree = "<group>"; };
+		A2E0151929933AF700EBACF0 /* BasicModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicModel.swift; sourceTree = "<group>"; };
+		A2E0151A29933AF700EBACF0 /* AnnouncementModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnouncementModel.swift; sourceTree = "<group>"; };
+		A2E0151D29933B0100EBACF0 /* APIManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		A2F6075329890F8C00F4F3DD /* FeedImgsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImgsCell.swift; sourceTree = "<group>"; };
 		A2F6075429890F8C00F4F3DD /* FeedImgsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FeedImgsCell.xib; sourceTree = "<group>"; };
 		A2F607582989632700F4F3DD /* ProductDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ProductDetail.storyboard; sourceTree = "<group>"; };
@@ -348,6 +354,7 @@
 		A2434AF02986589400F60D1A /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				A2E0151D29933B0100EBACF0 /* APIManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -355,6 +362,8 @@
 		A2434AF12986589D00F60D1A /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				A2E0151A29933AF700EBACF0 /* AnnouncementModel.swift */,
+				A2E0151929933AF700EBACF0 /* BasicModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -722,6 +731,7 @@
 				73FE8BA9298FEDAE00264B44 /* SearchDetailCell.swift in Sources */,
 				738F64902988A9B3006BB124 /* StoreProductViewController.swift in Sources */,
 				A2434B0229865B1A00F60D1A /* AnnouncementViewController.swift in Sources */,
+				A2E0151E29933B0100EBACF0 /* APIManager.swift in Sources */,
 				73FE8B9D298FEDAE00264B44 /* RecentCakeCell.swift in Sources */,
 				73FE8BA3298FEDAE00264B44 /* SearchMainViewController.swift in Sources */,
 				738F64972988A9BE006BB124 /* StoreImageCell.swift in Sources */,
@@ -729,11 +739,13 @@
 				731AA69E298D016D008A9A1B /* DayTableViewController.swift in Sources */,
 				A2784ADB298A9E0F00FE23DF /* PolicyWebViewController.swift in Sources */,
 				735AC116298D04570099B549 /* DayAddViewController.swift in Sources */,
+				A2E0151C29933AF700EBACF0 /* AnnouncementModel.swift in Sources */,
 				738F64902988A9B3006BB124 /* StoreProductViewController.swift in Sources */,
 				A2434B0229865B1A00F60D1A /* AnnouncementViewController.swift in Sources */,
 				73FE8BA4298FEDAE00264B44 /* SearchViewController.swift in Sources */,
 				738F64972988A9BE006BB124 /* StoreImageCell.swift in Sources */,
 				A2434ACC298651F500F60D1A /* SceneDelegate.swift in Sources */,
+				A2E0151B29933AF700EBACF0 /* BasicModel.swift in Sources */,
 				A2F607632989F53A00F4F3DD /* UIViewController+.swift in Sources */,
 				A2504B9D298B513100FF3CAC /* DefaultTabBarController.swift in Sources */,
 				A2B1CD5D29874E7E00D87570 /* AuthorityGuidanceViewController.swift in Sources */,

--- a/KeKi/Data/Model/AnnouncementModel.swift
+++ b/KeKi/Data/Model/AnnouncementModel.swift
@@ -1,0 +1,33 @@
+//
+//  AnnouncementModel.swift
+//  KeKi
+//
+//  Created by 김초원 on 2023/02/07.
+//
+
+import Foundation
+
+// MARK: 공지사항에 대한 서버 통신에 필요한 데이터 모델 정의
+struct AnnouncementListResponse: Decodable {
+    var isSuccess: Bool
+    var code: Int
+    var message: String
+    var result: [Result]
+    
+    struct Result: Decodable {
+        var noticeIdx: Int
+        var noticeTitle: String
+    }
+}
+
+struct AnnouncementResponse: Decodable {
+    var isSuccess: Bool
+    var code: Int
+    var message: String
+    var result: Announcement
+    
+    struct Announcement: Decodable {
+        var noticeTitle: String
+        var noticeContent: String
+    }
+}

--- a/KeKi/Data/Model/BasicModel.swift
+++ b/KeKi/Data/Model/BasicModel.swift
@@ -1,0 +1,15 @@
+//
+//  BasicModel.swift
+//  KeKi
+//
+//  Created by 김초원 on 2023/02/07.
+//
+
+import Foundation
+
+// MARK: POST 요청에 대한 응답이 거의 통일된 형태이므로, 공통된 Response 데이터 모델을 정의
+struct GeneralResponseModel: Decodable {
+    var isSuccess: Bool?
+    var code: Int?
+    var message: String?
+}

--- a/KeKi/Data/Network/APIManager.swift
+++ b/KeKi/Data/Network/APIManager.swift
@@ -1,0 +1,111 @@
+//
+//  APIManager.swift
+//  KeKi
+//
+//  Created by 김초원 on 2023/02/07.
+//
+
+import Foundation
+import Alamofire
+
+private let DEV_BASE_URL = "https://keki-dev.store" // 개발용 
+
+private let buyerAccessToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWR4IjoyLCJzdWIiOiIyIiwiZXhwIjoxNjc1NjkzODU4fQ.UHvkEhWXzpyVt7FfyLT5fYiifEm42yJmhKi1ru4zqk0"    // 임시 구매자 액세스 토큰
+private let sellerAccessToken = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWR4IjoxLCJzdWIiOiIxIiwiZXhwIjoxNjc1NjkzODMzfQ.4o2Lc_tMUvQJY1PP_dPQOxeOaeRVkT-HyUciBR_659s"    // 임시 판매자 액세스 토큰
+
+class APIManeger {
+    
+    // 임시 액세스 토큰 (구매자,판매자)
+    private let buyerTokenHeader = HTTPHeaders(["Authorization": buyerAccessToken])
+    private let sellerTokenHeader = HTTPHeaders(["Authorization": buyerAccessToken])
+    
+    static let apiManager = APIManeger()    // 과한 객체 생성으로 인한 메모리 낭비를 줄이기 위함
+    
+    // MARK: 제네릭을 활용한 서버와의 GET 통신 메소드
+    // ---
+    // ---
+    // T -> Decodable 프로토콜을 준수하는 데이터 모델 타입 (Ex. AnnouncementListResponse 참조)
+    // urlEndpointString -> get 메소드를 통한 통신을 할 api url에서 BASE URL을 제외한 나머지 url 문자열
+    // completionHandler -> 아래 메소드를 통해 서버로부터 데이터를 가져온 후, VC에서 해당 데이터를 가지고 어떤 작업을 할 건지 정의(여기서 정의하는 것 X, VC에서 getData 메소드 호출하면서 정의)
+    // ---
+    // 제네릭을 사용하였기 때문에, 성공적으로 데이터를 가져온다면 서버에서 주는 JSON 데이터를 통째로 받아옴 (switch문의 .success 케이스)
+    // 때문에 VC에서 필요한 부분만 추출하여 사용하는 것에 유의
+    func getData<T: Decodable>(urlEndpointString: String,
+                               dataType: T.Type,
+                               header: HTTPHeaders?,
+                               completionHandler: @escaping (T)->Void) {
+        
+        guard let url = URL(string: DEV_BASE_URL + urlEndpointString) else { return }
+        
+        AF
+            .request(url, method: .get, headers: header ?? nil)
+            .responseDecodable(of: T.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+
+    // MARK: 제네릭을 사용하지 않았을 경우의 get 통신 메소드 (회의 후 삭제 예정)
+    func getAnnouncementList(completionHandler: @escaping ([AnnouncementListResponse.Result])->Void) {
+        guard let url = URL(string: DEV_BASE_URL + "/cs/notice") else { return }
+        
+        AF
+            .request(url, method: .get)
+            .responseDecodable(of: AnnouncementListResponse.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success.result)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    func getAnnouncement(index: Int, completionHandler: @escaping (AnnouncementResponse.Announcement)->Void) {
+        guard let url = URL(string: DEV_BASE_URL + "/cs/notice/\(index)") else { return }
+
+        AF
+            .request(url, method: .get)
+            .responseDecodable(of: AnnouncementResponse.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success.result)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    
+    // MARK: 제네릭을 활용한 서버와의 POST 통신 메소드 - Response에 대한 nil 이슈 있음 (수정 예정)
+    func postData<T: Codable>(urlEndpointString: String,
+                              dataType: T.Type,
+                              header: HTTPHeaders?,
+                              parameter: T,
+                              completionHandler: @escaping (GeneralResponseModel) -> Void) {
+        guard let url = URL(string: DEV_BASE_URL + urlEndpointString) else { return }
+
+        AF
+            .request(url,
+                     method: .post,
+                     parameters: parameter,
+                     headers: header)
+            .responseDecodable(of: GeneralResponseModel.self) { response in
+                print(parameter)
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+}

--- a/KeKi/Data/Network/APIManager.swift
+++ b/KeKi/Data/Network/APIManager.swift
@@ -84,7 +84,7 @@ class APIManeger {
     }
     
     
-    // MARK: 제네릭을 활용한 서버와의 POST 통신 메소드 - Response에 대한 nil 이슈 있음 (수정 예정)
+    // MARK: 제네릭을 활용한 서버와의 POST 통신 메소드
     func postData<T: Codable>(urlEndpointString: String,
                               dataType: T.Type,
                               header: HTTPHeaders?,
@@ -96,6 +96,7 @@ class APIManeger {
             .request(url,
                      method: .post,
                      parameters: parameter,
+                     encoder: .json,
                      headers: header)
             .responseDecodable(of: GeneralResponseModel.self) { response in
                 print(parameter)

--- a/KeKi/Data/Network/APIManager.swift
+++ b/KeKi/Data/Network/APIManager.swift
@@ -90,6 +90,7 @@ class APIManeger {
                               header: HTTPHeaders?,
                               parameter: T,
                               completionHandler: @escaping (GeneralResponseModel) -> Void) {
+        
         guard let url = URL(string: DEV_BASE_URL + urlEndpointString) else { return }
 
         AF
@@ -99,7 +100,32 @@ class APIManeger {
                      encoder: .json,
                      headers: header)
             .responseDecodable(of: GeneralResponseModel.self) { response in
-                print(parameter)
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    // MARK: 제네릭을 활용한 서버와의 PATCH 통신 메소드 -
+    func patchData<T: Codable>(urlEndpointString: String,
+                               dataType: T.Type,
+                               header: HTTPHeaders?,
+                               parameter: T,
+                               completionHandler: @escaping (GeneralResponseModel) -> Void) {
+        
+        guard let url = URL(string: DEV_BASE_URL + urlEndpointString) else { return }
+
+        AF
+            .request(url,
+                     method: .patch,
+                     parameters: parameter,
+                     encoder: .json,
+                     headers: header)
+            .responseDecodable(of: GeneralResponseModel.self) { response in
                 switch response.result {
                 case .success(let success):
                     completionHandler(success)

--- a/KeKi/Scenes/Announcement/AnnouncementDetailViewController.swift
+++ b/KeKi/Scenes/Announcement/AnnouncementDetailViewController.swift
@@ -7,9 +7,13 @@
 
 import UIKit
 
+private var URL_ENDPOINT_STR = "/cs/notice/"
+
 class AnnouncementDetailViewController: UIViewController {
 
     // MARK: - Variables, IBOutlet, ...
+    private var index: String!
+
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var detailTextView: UITextView!
@@ -19,6 +23,7 @@ class AnnouncementDetailViewController: UIViewController {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = false
         setupLayout()
+        fetchData()
     }
     
     // MARK: - Action Methods (IBAction, ...)
@@ -40,3 +45,14 @@ class AnnouncementDetailViewController: UIViewController {
 }
 
 // MARK: - Extensions
+extension AnnouncementDetailViewController {
+    func setIndex(index: Int) { self.index = String(index) }
+    
+    private func fetchData(){
+        APIManeger.apiManager.getData(urlEndpointString: URL_ENDPOINT_STR + index, dataType: AnnouncementResponse.self, header: nil, completionHandler: { [weak self] response in
+            print(response)
+            self?.titleLabel.text = response.result.noticeTitle
+            self?.detailTextView.text = response.result.noticeContent
+        })
+    }
+}

--- a/KeKi/Scenes/Announcement/AnnouncementViewController.swift
+++ b/KeKi/Scenes/Announcement/AnnouncementViewController.swift
@@ -7,25 +7,28 @@
 
 import UIKit
 
+private let URL_ENDPOINT_STR = "/cs/notice"
+
 class AnnouncementViewController: UIViewController {
 
     // MARK: - Variables, IBOutlet, ...
-    private var announcementList: [String] = [  // 임시 데이터 (서버연결 후 삭제 예정)
-        "새로운 디저트가 등록되었어요!",
-        "크리스마스 기념 할인행사",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요! 어서 확인해보세요",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-        "새로운 디저트가 등록되었어요!",
-    ]
+    private var announcementList: [AnnouncementListResponse.Result] = []
+//    private var announcementList: [String] = [  // 임시 데이터 (서버연결 후 삭제 예정)
+//        "새로운 디저트가 등록되었어요!",
+//        "크리스마스 기념 할인행사",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요! 어서 확인해보세요",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//        "새로운 디저트가 등록되었어요!",
+//    ]
     
     @IBOutlet weak var tableView: UITableView!
     
@@ -34,6 +37,7 @@ class AnnouncementViewController: UIViewController {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = false
         setupTableView()
+        fetchData()
     }
     
     // MARK: - Action Methods (IBAction, ...)
@@ -57,7 +61,7 @@ extension AnnouncementViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "AnnouncementCell", for: indexPath)
                 as? AnnouncementCell else { return UITableViewCell() }
-        cell.titleLabel.text = announcementList[indexPath.row]
+        cell.titleLabel.text = announcementList[indexPath.row].noticeTitle
         cell.setupLayout()
         return cell
     }
@@ -73,7 +77,17 @@ extension AnnouncementViewController: UITableViewDelegate {
         let backItem = UIBarButtonItem()
         backItem.title = "공지사항"
         navigationItem.backBarButtonItem = backItem
+        let index = announcementList[indexPath.row].noticeIdx
+        detailView.setIndex(index: index)
         navigationController?.pushViewController(detailView, animated: true)
     }
 }
 
+extension AnnouncementViewController {
+    private func fetchData() {
+        APIManeger.apiManager.getData(urlEndpointString: URL_ENDPOINT_STR, dataType: AnnouncementListResponse.self, header: nil, completionHandler: { [weak self] response in
+            self?.announcementList = response.result
+            self?.tableView.reloadData()
+        })
+    }
+}


### PR DESCRIPTION
## 📚 이슈 번호
#32 

## 💬 기타 사항
- 데이터 모델 샘플과 GET / POST / PATCH 메소드 작성해두었습니당 
- 공지관련 화면에서는 GET 통신만 하기 때문에, POST와 PATCH 메소드를 정의할 때에는 캘린더를 기준으로 테스트해보며 작성했습니당
- 정기회의 이후에 서버 통신하면서 필요시 업데이트 하는걸루!
- 공지는 서버로부터 데이터를 받아와 유저에게 보여지도록 컴포넌트에 값을 설정해주는 부분까지 구현되어 있습니당
