### PR TITLE
[Feature] 피드 상세 화면 서버 연동 및 화면 연결

### DIFF
--- a/KeKi.xcodeproj/project.pbxproj
+++ b/KeKi.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		A2784ADD298AA9C700FE23DF /* Alert.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2784ADC298AA9C700FE23DF /* Alert.storyboard */; };
 		A2784ADF298AA9D800FE23DF /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2784ADE298AA9D800FE23DF /* AlertViewController.swift */; };
 		A2784AE2298AB50100FE23DF /* PolicyWebView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2784AE1298AB50100FE23DF /* PolicyWebView.storyboard */; };
+		A2A7966729A4E76700A2F2E2 /* FeedModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A7966629A4E76700A2F2E2 /* FeedModel.swift */; };
 		A2B1CD5B29874E6C00D87570 /* AuthorityGuidance.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2B1CD5A29874E6C00D87570 /* AuthorityGuidance.storyboard */; };
 		A2B1CD5D29874E7E00D87570 /* AuthorityGuidanceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B1CD5C29874E7E00D87570 /* AuthorityGuidanceViewController.swift */; };
 		A2B1CD5F29875D9E00D87570 /* SelectUserCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B1CD5E29875D9E00D87570 /* SelectUserCategoryViewController.swift */; };
@@ -161,6 +162,7 @@
 		A2784ADC298AA9C700FE23DF /* Alert.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Alert.storyboard; sourceTree = "<group>"; };
 		A2784ADE298AA9D800FE23DF /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		A2784AE1298AB50100FE23DF /* PolicyWebView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PolicyWebView.storyboard; sourceTree = "<group>"; };
+		A2A7966629A4E76700A2F2E2 /* FeedModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedModel.swift; sourceTree = "<group>"; };
 		A2B1CD5A29874E6C00D87570 /* AuthorityGuidance.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AuthorityGuidance.storyboard; sourceTree = "<group>"; };
 		A2B1CD5C29874E7E00D87570 /* AuthorityGuidanceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorityGuidanceViewController.swift; sourceTree = "<group>"; };
 		A2B1CD5E29875D9E00D87570 /* SelectUserCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectUserCategoryViewController.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				7367E1D4299A1546008E517F /* SearchModel.swift */,
 				A2E7D14729A0CA8100110CD2 /* AuthModel.swift */,
 				A23F2DAC29A1F3BF0046ED70 /* HomeModel.swift */,
+				A2A7966629A4E76700A2F2E2 /* FeedModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -707,6 +710,7 @@
 				738F64992988A9BE006BB124 /* TabViewController.swift in Sources */,
 				731AA68F298D00C0008A9A1B /* SettingTableViewCell.swift in Sources */,
 				A2B1CD7D2988EFE900D87570 /* FeedViewController.swift in Sources */,
+				A2A7966729A4E76700A2F2E2 /* FeedModel.swift in Sources */,
 				A2B1CD612987687F00D87570 /* BuyerProfileSetViewController.swift in Sources */,
 				A2F6075529890F8C00F4F3DD /* FeedImgsCell.swift in Sources */,
 				731AA6A0298D016D008A9A1B /* DayCell.swift in Sources */,

--- a/KeKi/Data/Model/FeedModel.swift
+++ b/KeKi/Data/Model/FeedModel.swift
@@ -14,3 +14,9 @@ struct SingleFeedResponse: Codable {
     var result: Feed
 }
 
+struct FeedResponse: Codable {
+    var isSuccess: Bool
+    var code: Int
+    var message: String
+    var result: [Feed]
+}

--- a/KeKi/Data/Model/FeedModel.swift
+++ b/KeKi/Data/Model/FeedModel.swift
@@ -1,0 +1,16 @@
+//
+//  FeedModel.swift
+//  KeKi
+//
+//  Created by 김초원 on 2023/02/21.
+//
+
+import Foundation
+
+struct SingleFeedResponse: Codable {
+    var isSuccess: Bool
+    var code: Int
+    var message: String
+    var result: Feed
+}
+

--- a/KeKi/Data/Model/HomeModel.swift
+++ b/KeKi/Data/Model/HomeModel.swift
@@ -30,6 +30,6 @@ struct HomeTagRes: Decodable {
 
 struct HomePostRes: Decodable {
     var postIdx: Int
-//    var storeTitle: String
+    var storeTitle: String
     var postImgUrl: String
 }

--- a/KeKi/Scenes/DefaultTabBarController.swift
+++ b/KeKi/Scenes/DefaultTabBarController.swift
@@ -52,6 +52,7 @@ class DefaultTabBarController: UITabBarController {
         calendar.tabBarItem = calendarTab
         
         guard let searchViewController = UIStoryboard(name: "Search", bundle: nil).instantiateViewController(withIdentifier: "SearchViewController") as? SearchViewController else {return}
+        let search = UINavigationController(rootViewController: searchViewController)
         searchViewController.tabBarItem = searchTab
         
         let heartViewController = UIViewController()
@@ -67,7 +68,7 @@ class DefaultTabBarController: UITabBarController {
             viewControllers = [
                 home,
                 calendar,
-                searchViewController,
+                search,
                 heartViewController,
                 mypage
             ]

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 protocol AlertDelegate {
     func showFeedMainAlert()
@@ -16,11 +17,7 @@ class FeedCell: UITableViewCell {
     
     var feedAlertDelegate: AlertDelegate!
     
-    var imageList: [String] = [
-        "a.circle",
-        "b.circle",
-        "c.circle"
-    ]
+    var imageList: [String] = []
 
     @IBOutlet weak var profileImgView: UIImageView!
     @IBOutlet weak var nicknameLabel: UILabel!
@@ -60,13 +57,14 @@ class FeedCell: UITableViewCell {
     
     func configure(data: Feed) {
         nicknameLabel.text = data.storeName
+        
         imageList = data.postImgUrls
-        // TODO: url을 통해 이미지 불러오기
+        pageControl.numberOfPages = imageList.count
+        pageControl.currentPage = 0
+        
         dessertNameButton.setTitle(data.dessertName, for: .normal)
         descriptionTextView.text = data.description
-        if data.like {
-            heartButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
-        }
+        if data.like { heartButton.setImage(UIImage(systemName: "heart.fill"), for: .normal) }
     }
     
     func setup() {
@@ -74,11 +72,6 @@ class FeedCell: UITableViewCell {
         imgCollectionView.dataSource = self
         imgCollectionView.delegate = self
         imgCollectionView.showsHorizontalScrollIndicator = false
-    }
-    
-    private func setupPageControl() {
-        pageControl.numberOfPages = imageList.count
-        pageControl.currentPage = 0
     }
 }
 
@@ -91,6 +84,8 @@ extension FeedCell: UICollectionViewDataSource {
         print(indexPath.row)
 
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "FeedImgsCell", for: indexPath) as? FeedImgsCell else { return UICollectionViewCell() }
+        let imgURL = imageList[indexPath.row]
+        cell.imgView.kf.setImage(with: URL(string: imgURL))
         return cell
     }
     

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -90,6 +90,7 @@ class FeedCell: UITableViewCell {
         
         dessertNameButton.setTitle(data.dessertName, for: .normal)
         descriptionTextView.text = data.description
+        descriptionTextView.sizeToFit()
         
         tagList = data.tags
         setTagButton()

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -52,12 +52,22 @@ class FeedCell: UITableViewCell {
     
     
     @IBAction func didTapViewmoreButton(_ sender: UIButton) {
-        print("didTapViewmoreButton")
         feedAlertDelegate.showFeedMainAlert()
     }
     
     @IBAction func didTapHeartButton(_ sender: UIButton) {
         heartButton.isSelected = !heartButton.isSelected
+        heartButton.isSelected ? postLikeFeed() : discardFeedLike()
+    }
+    
+    private func postLikeFeed() {
+        // TODO: 피드 찜하기 기능
+        print("찜 하기")
+    }
+    
+    private func discardFeedLike() {
+        // TODO: 피드 찜 취소하기 기능
+        print("찜 취소")
     }
     
     func setSingleFeedView() { separatorView.isHidden = true }

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -57,6 +57,12 @@ class FeedCell: UITableViewCell {
     
     func configure(data: Feed) {
         nicknameLabel.text = data.storeName
+
+        profileImgView.kf.setImage(with: URL(string: data.storeProfileImg))
+        profileImgView.layer.cornerRadius = profileImgView.frame.width / 2
+        
+        profileImgView.layer.borderWidth = 0.3  // 정방형이 아닌 크기의 프로필 사진에 대한 임시처리
+        profileImgView.layer.borderColor = UIColor.lightGray.cgColor    // 정방형이 아닌 크기의 프로필 사진에 대한 임시처리
         
         imageList = data.postImgUrls
         pageControl.numberOfPages = imageList.count

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -18,6 +18,7 @@ class FeedCell: UITableViewCell {
     var feedAlertDelegate: AlertDelegate!
     
     var imageList: [String] = []
+    var tagList: [String] = []
 
     @IBOutlet weak var profileImgView: UIImageView!
     @IBOutlet weak var nicknameLabel: UILabel!
@@ -28,6 +29,10 @@ class FeedCell: UITableViewCell {
     @IBOutlet weak var dessertNameButton: UIButton!
     @IBOutlet weak var descriptionTextView: UITextView!
     
+    @IBOutlet weak var tag1Button: UIButton!
+    @IBOutlet weak var tag2Button: UIButton!
+    @IBOutlet weak var tag3Button: UIButton!
+    
     @IBOutlet weak var heartButton: UIButton!
     @IBOutlet weak var separatorView: UIView!
     
@@ -36,6 +41,9 @@ class FeedCell: UITableViewCell {
         imgCollectionView.register(UINib(nibName: "FeedImgsCell", bundle: nil), forCellWithReuseIdentifier: "FeedImgsCell")
         heartButton.setImage(UIImage(systemName: "heart"), for: .normal)
         heartButton.setImage(UIImage(systemName: "heart.fill"), for: .selected)
+        [tag1Button,tag2Button,tag3Button].forEach {
+            $0?.layer.cornerRadius = 15
+        }
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -56,6 +64,7 @@ class FeedCell: UITableViewCell {
     func reloadData() { imgCollectionView.reloadData() }
     
     func configure(data: Feed) {
+        // set store profile
         nicknameLabel.text = data.storeName
 
         profileImgView.kf.setImage(with: URL(string: data.storeProfileImg))
@@ -64,12 +73,17 @@ class FeedCell: UITableViewCell {
         profileImgView.layer.borderWidth = 0.3  // 정방형이 아닌 크기의 프로필 사진에 대한 임시처리
         profileImgView.layer.borderColor = UIColor.lightGray.cgColor    // 정방형이 아닌 크기의 프로필 사진에 대한 임시처리
         
+        // set dessert contents
         imageList = data.postImgUrls
         pageControl.numberOfPages = imageList.count
         pageControl.currentPage = 0
         
         dessertNameButton.setTitle(data.dessertName, for: .normal)
         descriptionTextView.text = data.description
+        
+        tagList = data.tags
+        setTagButton()
+        
         if data.like { heartButton.setImage(UIImage(systemName: "heart.fill"), for: .normal) }
     }
     
@@ -78,6 +92,25 @@ class FeedCell: UITableViewCell {
         imgCollectionView.dataSource = self
         imgCollectionView.delegate = self
         imgCollectionView.showsHorizontalScrollIndicator = false
+    }
+    
+    func setTagButton() {
+        switch tagList.count {
+        case 1:
+            tag1Button.setTitle("# \(tagList[0])", for: .normal)
+            [ tag2Button, tag3Button ].forEach { $0?.isHidden = true }
+        case 2:
+            tag1Button.setTitle("# \(tagList[0])", for: .normal)
+            tag2Button.setTitle("# \(tagList[1])", for: .normal)
+            [ tag3Button ].forEach { $0?.isHidden = true }
+        case 3:
+            tag1Button.setTitle("# \(tagList[0])", for: .normal)
+            tag2Button.setTitle("# \(tagList[1])", for: .normal)
+            tag3Button.setTitle("# \(tagList[2])", for: .normal)
+
+        default:
+            return
+        }
     }
 }
 

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -89,7 +89,6 @@ class FeedCell: UITableViewCell {
         pageControl.currentPage = 0
         
         dessertNameButton.setTitle(data.dessertName, for: .normal)
-//        dessertNameButton.titleLabel.font = UIFont.boldSystemFont(ofSize: 17)
         descriptionTextView.text = data.description
         descriptionTextView.sizeToFit()
         
@@ -159,34 +158,5 @@ extension FeedCell: UICollectionViewDelegateFlowLayout {
         if pageControl.currentPage != newPage {
             pageControl.currentPage = newPage
         }
-    }
-}
-
-
-extension String {
-    func attributed(of searchString: String, value: [NSAttributedString.Key: Any]) -> NSMutableAttributedString {
-    
-        let attributedString = NSMutableAttributedString(string: self)
-        let length = self.count
-        
-        var range = NSRange(location: 0, length: length)
-        var rangeArray = [NSRange]()
-
-        while range.location != NSNotFound {
-            range = (attributedString.string as NSString).range(of: searchString, options: .caseInsensitive, range: range)
-            rangeArray.append(range)
-
-            if range.location != NSNotFound {
-                range = NSRange(location: range.location + range.length, length: self.count - (range.location + range.length))
-            }
-        }
-        
-        rangeArray.forEach { range in
-            value.forEach { values in
-                attributedString.addAttribute(values.key, value: values.value, range: range)
-            }
-        }
-
-        return attributedString
     }
 }

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -28,7 +28,11 @@ class FeedCell: UITableViewCell {
     @IBOutlet weak var imgCollectionView: UICollectionView!
     @IBOutlet weak var pageControl: UIPageControl!
     
+    @IBOutlet weak var dessertNameButton: UIButton!
+    @IBOutlet weak var descriptionTextView: UITextView!
+    
     @IBOutlet weak var heartButton: UIButton!
+    @IBOutlet weak var separatorView: UIView!
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -51,10 +55,21 @@ class FeedCell: UITableViewCell {
         heartButton.isSelected = !heartButton.isSelected
     }
     
+    func setSingleFeedView() { separatorView.isHidden = true }
+    func reloadData() { imgCollectionView.reloadData() }
+    
+    func configure(data: Feed) {
+        nicknameLabel.text = data.storeName
+        imageList = data.postImgUrls
+        // TODO: url을 통해 이미지 불러오기
+        dessertNameButton.setTitle(data.dessertName, for: .normal)
+        descriptionTextView.text = data.description
+        if data.like {
+            heartButton.setImage(UIImage(systemName: "heart.fill"), for: .normal)
+        }
+    }
     
     func setup() {
-        
-        
         imgCollectionView.isPagingEnabled = true
         imgCollectionView.dataSource = self
         imgCollectionView.delegate = self

--- a/KeKi/Scenes/Feed/FeedCell.swift
+++ b/KeKi/Scenes/Feed/FeedCell.swift
@@ -89,6 +89,7 @@ class FeedCell: UITableViewCell {
         pageControl.currentPage = 0
         
         dessertNameButton.setTitle(data.dessertName, for: .normal)
+//        dessertNameButton.titleLabel.font = UIFont.boldSystemFont(ofSize: 17)
         descriptionTextView.text = data.description
         descriptionTextView.sizeToFit()
         
@@ -162,3 +163,30 @@ extension FeedCell: UICollectionViewDelegateFlowLayout {
 }
 
 
+extension String {
+    func attributed(of searchString: String, value: [NSAttributedString.Key: Any]) -> NSMutableAttributedString {
+    
+        let attributedString = NSMutableAttributedString(string: self)
+        let length = self.count
+        
+        var range = NSRange(location: 0, length: length)
+        var rangeArray = [NSRange]()
+
+        while range.location != NSNotFound {
+            range = (attributedString.string as NSString).range(of: searchString, options: .caseInsensitive, range: range)
+            rangeArray.append(range)
+
+            if range.location != NSNotFound {
+                range = NSRange(location: range.location + range.length, length: self.count - (range.location + range.length))
+            }
+        }
+        
+        rangeArray.forEach { range in
+            value.forEach { values in
+                attributedString.addAttribute(values.key, value: values.value, range: range)
+            }
+        }
+
+        return attributedString
+    }
+}

--- a/KeKi/Scenes/Feed/FeedCell.xib
+++ b/KeKi/Scenes/Feed/FeedCell.xib
@@ -110,6 +110,7 @@
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oSK-8L-8m5">
                         <rect key="frame" x="267" y="535" width="30" height="30"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="30" id="73W-qA-14W"/>
                             <constraint firstAttribute="width" constant="30" id="7T8-bY-lF3"/>

--- a/KeKi/Scenes/Feed/FeedCell.xib
+++ b/KeKi/Scenes/Feed/FeedCell.xib
@@ -187,11 +187,14 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="descriptionTextView" destination="p5c-uC-NH0" id="QUn-Kh-Qgg"/>
+                <outlet property="dessertNameButton" destination="e88-AC-HKz" id="WhV-JV-MxE"/>
                 <outlet property="heartButton" destination="oSK-8L-8m5" id="i6G-9K-QgR"/>
                 <outlet property="imgCollectionView" destination="Gau-NA-CUj" id="xGE-l6-Dhx"/>
                 <outlet property="nicknameLabel" destination="IAu-II-bYw" id="voi-i0-dEt"/>
                 <outlet property="pageControl" destination="e5N-ye-wT5" id="o5C-gy-Giy"/>
                 <outlet property="profileImgView" destination="Hhf-r6-Vgn" id="SJz-3i-eRH"/>
+                <outlet property="separatorView" destination="OuS-tT-pVB" id="c2N-wI-o2v"/>
             </connections>
             <point key="canvasLocation" x="138.93129770992365" y="19.718309859154932"/>
         </tableViewCell>

--- a/KeKi/Scenes/Feed/FeedCell.xib
+++ b/KeKi/Scenes/Feed/FeedCell.xib
@@ -74,42 +74,46 @@
                         </collectionViewFlowLayout>
                     </collectionView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fLN-MI-dcj">
-                        <rect key="frame" x="23" y="533.33333333333337" width="176" height="30"/>
+                        <rect key="frame" x="16" y="533.33333333333337" width="166" height="30"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O7K-SM-5nP">
-                                <rect key="frame" x="0.0" y="0.0" width="53.333333333333336" height="30"/>
+                                <rect key="frame" x="0.0" y="0.0" width="50" height="30"/>
                                 <color key="backgroundColor" red="0.9882352941176471" green="0.95686274509803915" blue="0.87450980392156863" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="B41-qR-eGd"/>
+                                    <constraint firstAttribute="width" constant="50" id="YDA-Hh-kDR"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
-                                </buttonConfiguration>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="# 친구"/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uP2-Kn-N8M">
-                                <rect key="frame" x="61.333333333333329" y="0.0" width="53.333333333333329" height="30"/>
+                                <rect key="frame" x="58" y="0.0" width="50" height="30"/>
                                 <color key="backgroundColor" red="0.98039215686274506" green="0.92549019607843142" blue="0.92549019607843142" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="50" id="fXX-Eo-WSE"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
-                                </buttonConfiguration>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="# 친구"/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgC-EV-uGu">
-                                <rect key="frame" x="122.66666666666664" y="0.0" width="53.333333333333329" height="30"/>
+                                <rect key="frame" x="116" y="0.0" width="50" height="30"/>
                                 <color key="backgroundColor" red="0.95686274510000002" green="0.79607843140000001" blue="0.79607843140000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="50" id="3VS-Ap-lfr"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <state key="normal" title="Button"/>
-                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
-                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
-                                </buttonConfiguration>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="# 친구"/>
                             </button>
                         </subviews>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oSK-8L-8m5">
-                        <rect key="frame" x="257" y="525" width="40" height="40"/>
+                        <rect key="frame" x="264" y="525" width="40" height="40"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="40" id="73W-qA-14W"/>
@@ -131,18 +135,17 @@
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e88-AC-HKz">
-                        <rect key="frame" x="16" y="394" width="83" height="25"/>
+                        <rect key="frame" x="21" y="394" width="59" height="25"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="25" id="KfH-aG-aGG"/>
                         </constraints>
+                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <state key="normal" title="Button"/>
-                        <buttonConfiguration key="configuration" style="plain" title="제품이름">
-                            <fontDescription key="titleFontDescription" type="boldSystem" pointSize="17"/>
-                        </buttonConfiguration>
+                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                        <state key="normal" title="제품이름"/>
                     </button>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구…이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구… 근데 이거 높이값 고정인가 아 집가고 싶다 아 초밥 먹고 싶은디 " textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="p5c-uC-NH0">
-                        <rect key="frame" x="23" y="429" width="274" height="89.333333333333371"/>
+                        <rect key="frame" x="16" y="429" width="288" height="89.333333333333371"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
@@ -150,7 +153,7 @@
                     </textView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="p5c-uC-NH0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="7" id="1aZ-NY-pdg"/>
+                    <constraint firstItem="p5c-uC-NH0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="1aZ-NY-pdg"/>
                     <constraint firstItem="e5N-ye-wT5" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="3pZ-ey-e4h"/>
                     <constraint firstItem="Gau-NA-CUj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Eel-RJ-sac"/>
                     <constraint firstItem="p5c-uC-NH0" firstAttribute="top" secondItem="e88-AC-HKz" secondAttribute="bottom" constant="10" id="GWy-0T-pfq"/>
@@ -166,7 +169,7 @@
                     <constraint firstItem="f3U-f8-ueK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Zd1-8h-BHd"/>
                     <constraint firstAttribute="trailing" secondItem="OuS-tT-pVB" secondAttribute="trailing" constant="10" id="aJo-ac-Iep"/>
                     <constraint firstItem="fLN-MI-dcj" firstAttribute="top" secondItem="p5c-uC-NH0" secondAttribute="bottom" constant="15" id="awt-2d-7gF"/>
-                    <constraint firstItem="e88-AC-HKz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="f2M-ov-lA2"/>
+                    <constraint firstItem="e88-AC-HKz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="5" id="f2M-ov-lA2"/>
                     <constraint firstItem="p5c-uC-NH0" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="fh5-dn-sWa"/>
                     <constraint firstAttribute="bottomMargin" secondItem="oSK-8L-8m5" secondAttribute="bottom" constant="24" id="iCF-sL-UOj"/>
                     <constraint firstItem="Gau-NA-CUj" firstAttribute="top" secondItem="f3U-f8-ueK" secondAttribute="bottom" constant="10" id="lAW-YT-tEx"/>

--- a/KeKi/Scenes/Feed/FeedCell.xib
+++ b/KeKi/Scenes/Feed/FeedCell.xib
@@ -56,7 +56,7 @@
                         </constraints>
                     </view>
                     <pageControl opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="e5N-ye-wT5">
-                        <rect key="frame" x="16" y="368" width="288" height="16"/>
+                        <rect key="frame" x="16" y="368" width="288" height="26"/>
                         <color key="pageIndicatorTintColor" red="0.98039215686274506" green="0.92549019607843142" blue="0.92549019607843142" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="currentPageIndicatorTintColor" red="0.85098039219999999" green="0.28235294119999998" blue="0.41568627450000001" alpha="0.84705882349999995" colorSpace="calibratedRGB"/>
                     </pageControl>
@@ -109,11 +109,11 @@
                         </subviews>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oSK-8L-8m5">
-                        <rect key="frame" x="267" y="535" width="30" height="30"/>
+                        <rect key="frame" x="257" y="525" width="40" height="40"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="30" id="73W-qA-14W"/>
-                            <constraint firstAttribute="width" constant="30" id="7T8-bY-lF3"/>
+                            <constraint firstAttribute="height" constant="40" id="73W-qA-14W"/>
+                            <constraint firstAttribute="width" constant="40" id="7T8-bY-lF3"/>
                             <constraint firstAttribute="width" secondItem="oSK-8L-8m5" secondAttribute="height" multiplier="1:1" id="O04-U6-Le2"/>
                         </constraints>
                         <color key="tintColor" red="0.8784313725490196" green="0.73333333333333328" blue="0.73333333333333328" alpha="1" colorSpace="calibratedRGB"/>
@@ -131,24 +131,21 @@
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e88-AC-HKz">
-                        <rect key="frame" x="16" y="384" width="79.666666666666671" height="25"/>
+                        <rect key="frame" x="16" y="394" width="83" height="25"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="25" id="KfH-aG-aGG"/>
                         </constraints>
                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <state key="normal" title="Button"/>
                         <buttonConfiguration key="configuration" style="plain" title="제품이름">
-                            <fontDescription key="titleFontDescription" type="boldSystem" pointSize="16"/>
+                            <fontDescription key="titleFontDescription" type="boldSystem" pointSize="17"/>
                         </buttonConfiguration>
                     </button>
-                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구…이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구… 근데 이거 높이값 고정인가 아 집가고 싶다 아 초밥 먹고 싶은디 " textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="p5c-uC-NH0">
-                        <rect key="frame" x="23" y="409" width="274" height="100"/>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구…이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구… 근데 이거 높이값 고정인가 아 집가고 싶다 아 초밥 먹고 싶은디 " textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="p5c-uC-NH0">
+                        <rect key="frame" x="23" y="429" width="274" height="89.333333333333371"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="100" id="RMM-39-reA"/>
-                        </constraints>
                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     </textView>
                 </subviews>
@@ -156,7 +153,7 @@
                     <constraint firstItem="p5c-uC-NH0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="7" id="1aZ-NY-pdg"/>
                     <constraint firstItem="e5N-ye-wT5" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="3pZ-ey-e4h"/>
                     <constraint firstItem="Gau-NA-CUj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Eel-RJ-sac"/>
-                    <constraint firstItem="p5c-uC-NH0" firstAttribute="top" secondItem="e88-AC-HKz" secondAttribute="bottom" id="GWy-0T-pfq"/>
+                    <constraint firstItem="p5c-uC-NH0" firstAttribute="top" secondItem="e88-AC-HKz" secondAttribute="bottom" constant="10" id="GWy-0T-pfq"/>
                     <constraint firstItem="e88-AC-HKz" firstAttribute="top" secondItem="e5N-ye-wT5" secondAttribute="bottom" id="HqE-fp-4de"/>
                     <constraint firstItem="e5N-ye-wT5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="IA1-v9-53U"/>
                     <constraint firstAttribute="trailing" secondItem="f3U-f8-ueK" secondAttribute="trailing" id="LjV-gC-LIB"/>
@@ -168,7 +165,7 @@
                     <constraint firstItem="fLN-MI-dcj" firstAttribute="leading" secondItem="p5c-uC-NH0" secondAttribute="leading" id="Y6u-8X-qf3"/>
                     <constraint firstItem="f3U-f8-ueK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Zd1-8h-BHd"/>
                     <constraint firstAttribute="trailing" secondItem="OuS-tT-pVB" secondAttribute="trailing" constant="10" id="aJo-ac-Iep"/>
-                    <constraint firstItem="fLN-MI-dcj" firstAttribute="top" secondItem="p5c-uC-NH0" secondAttribute="bottom" constant="24.329999999999998" id="awt-2d-7gF"/>
+                    <constraint firstItem="fLN-MI-dcj" firstAttribute="top" secondItem="p5c-uC-NH0" secondAttribute="bottom" constant="15" id="awt-2d-7gF"/>
                     <constraint firstItem="e88-AC-HKz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="f2M-ov-lA2"/>
                     <constraint firstItem="p5c-uC-NH0" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="fh5-dn-sWa"/>
                     <constraint firstAttribute="bottomMargin" secondItem="oSK-8L-8m5" secondAttribute="bottom" constant="24" id="iCF-sL-UOj"/>

--- a/KeKi/Scenes/Feed/FeedCell.xib
+++ b/KeKi/Scenes/Feed/FeedCell.xib
@@ -56,7 +56,7 @@
                         </constraints>
                     </view>
                     <pageControl opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="e5N-ye-wT5">
-                        <rect key="frame" x="16" y="368" width="288" height="26"/>
+                        <rect key="frame" x="16" y="368" width="288" height="16"/>
                         <color key="pageIndicatorTintColor" red="0.98039215686274506" green="0.92549019607843142" blue="0.92549019607843142" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="currentPageIndicatorTintColor" red="0.85098039219999999" green="0.28235294119999998" blue="0.41568627450000001" alpha="0.84705882349999995" colorSpace="calibratedRGB"/>
                     </pageControl>
@@ -74,49 +74,45 @@
                         </collectionViewFlowLayout>
                     </collectionView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="fLN-MI-dcj">
-                        <rect key="frame" x="23" y="543.33333333333337" width="108" height="20"/>
+                        <rect key="frame" x="23" y="533.33333333333337" width="176" height="30"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0C8-C9-Z45">
-                                <rect key="frame" x="0.0" y="0.0" width="50" height="20"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="# 친구" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g6q-O0-oCp">
-                                        <rect key="frame" x="10.333333333333334" y="3.3333333333332584" width="29.333333333333329" height="13.333333333333336"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" red="0.98823529409999999" green="0.95686274510000002" blue="0.87450980389999999" alpha="1" colorSpace="calibratedRGB"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O7K-SM-5nP">
+                                <rect key="frame" x="0.0" y="0.0" width="53.333333333333336" height="30"/>
+                                <color key="backgroundColor" red="0.9882352941176471" green="0.95686274509803915" blue="0.87450980392156863" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstItem="g6q-O0-oCp" firstAttribute="centerX" secondItem="0C8-C9-Z45" secondAttribute="centerX" id="ENZ-fn-QPG"/>
-                                    <constraint firstItem="g6q-O0-oCp" firstAttribute="centerY" secondItem="0C8-C9-Z45" secondAttribute="centerY" id="Hw5-CV-KuN"/>
-                                    <constraint firstAttribute="width" constant="50" id="U2X-iO-GqV"/>
-                                    <constraint firstAttribute="height" constant="20" id="wFR-z4-eGs"/>
+                                    <constraint firstAttribute="height" constant="30" id="B41-qR-eGd"/>
                                 </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R6h-JA-aYt">
-                                <rect key="frame" x="58" y="0.0" width="50" height="20"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="# 가족" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="veS-uM-JWF">
-                                        <rect key="frame" x="10.333333333333327" y="3.3333333333332584" width="29.333333333333329" height="13.333333333333336"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" red="0.85098039219999999" green="0.28235294119999998" blue="0.41568627450000001" alpha="0.30429946192052981" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstItem="veS-uM-JWF" firstAttribute="centerX" secondItem="R6h-JA-aYt" secondAttribute="centerX" id="47U-mv-a8X"/>
-                                    <constraint firstAttribute="height" constant="20" id="PtT-Cl-OZ3"/>
-                                    <constraint firstItem="veS-uM-JWF" firstAttribute="centerY" secondItem="R6h-JA-aYt" secondAttribute="centerY" id="acD-QS-dAO"/>
-                                    <constraint firstAttribute="width" constant="50" id="eSj-BN-85C"/>
-                                </constraints>
-                            </view>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
+                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
+                                </buttonConfiguration>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uP2-Kn-N8M">
+                                <rect key="frame" x="61.333333333333329" y="0.0" width="53.333333333333329" height="30"/>
+                                <color key="backgroundColor" red="0.98039215686274506" green="0.92549019607843142" blue="0.92549019607843142" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
+                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
+                                </buttonConfiguration>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hgC-EV-uGu">
+                                <rect key="frame" x="122.66666666666664" y="0.0" width="53.333333333333329" height="30"/>
+                                <color key="backgroundColor" red="0.95686274510000002" green="0.79607843140000001" blue="0.79607843140000001" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="# 친구">
+                                    <fontDescription key="titleFontDescription" type="system" pointSize="11"/>
+                                </buttonConfiguration>
+                            </button>
                         </subviews>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oSK-8L-8m5">
-                        <rect key="frame" x="277" y="543.33333333333337" width="20" height="20"/>
+                        <rect key="frame" x="267" y="535" width="30" height="30"/>
                         <constraints>
+                            <constraint firstAttribute="height" constant="30" id="73W-qA-14W"/>
+                            <constraint firstAttribute="width" constant="30" id="7T8-bY-lF3"/>
                             <constraint firstAttribute="width" secondItem="oSK-8L-8m5" secondAttribute="height" multiplier="1:1" id="O04-U6-Le2"/>
                         </constraints>
                         <color key="tintColor" red="0.8784313725490196" green="0.73333333333333328" blue="0.73333333333333328" alpha="1" colorSpace="calibratedRGB"/>
@@ -134,7 +130,7 @@
                         </constraints>
                     </view>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e88-AC-HKz">
-                        <rect key="frame" x="16" y="394" width="79.666666666666671" height="25"/>
+                        <rect key="frame" x="16" y="384" width="79.666666666666671" height="25"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="25" id="KfH-aG-aGG"/>
                         </constraints>
@@ -145,7 +141,7 @@
                         </buttonConfiguration>
                     </button>
                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구…이 제품은 어쩌구저쩌구 케이크어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구… 근데 이거 높이값 고정인가 아 집가고 싶다 아 초밥 먹고 싶은디 " textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="p5c-uC-NH0">
-                        <rect key="frame" x="23" y="419" width="274" height="100"/>
+                        <rect key="frame" x="23" y="409" width="274" height="100"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="100" id="RMM-39-reA"/>
@@ -174,8 +170,7 @@
                     <constraint firstItem="fLN-MI-dcj" firstAttribute="top" secondItem="p5c-uC-NH0" secondAttribute="bottom" constant="24.329999999999998" id="awt-2d-7gF"/>
                     <constraint firstItem="e88-AC-HKz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="f2M-ov-lA2"/>
                     <constraint firstItem="p5c-uC-NH0" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="fh5-dn-sWa"/>
-                    <constraint firstItem="oSK-8L-8m5" firstAttribute="height" secondItem="R6h-JA-aYt" secondAttribute="height" id="hvy-ix-A9b"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="oSK-8L-8m5" secondAttribute="bottom" constant="25.670000000000002" id="iCF-sL-UOj"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="oSK-8L-8m5" secondAttribute="bottom" constant="24" id="iCF-sL-UOj"/>
                     <constraint firstItem="Gau-NA-CUj" firstAttribute="top" secondItem="f3U-f8-ueK" secondAttribute="bottom" constant="10" id="lAW-YT-tEx"/>
                     <constraint firstItem="e5N-ye-wT5" firstAttribute="top" secondItem="Gau-NA-CUj" secondAttribute="bottom" id="rdJ-RN-LEl"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Gau-NA-CUj" secondAttribute="trailing" id="riz-dA-vCM"/>
@@ -195,6 +190,9 @@
                 <outlet property="pageControl" destination="e5N-ye-wT5" id="o5C-gy-Giy"/>
                 <outlet property="profileImgView" destination="Hhf-r6-Vgn" id="SJz-3i-eRH"/>
                 <outlet property="separatorView" destination="OuS-tT-pVB" id="c2N-wI-o2v"/>
+                <outlet property="tag1Button" destination="O7K-SM-5nP" id="Prv-LF-kf4"/>
+                <outlet property="tag2Button" destination="uP2-Kn-N8M" id="Lwn-Ci-8Dr"/>
+                <outlet property="tag3Button" destination="hgC-EV-uGu" id="Plc-yS-2Vg"/>
             </connections>
             <point key="canvasLocation" x="138.93129770992365" y="19.718309859154932"/>
         </tableViewCell>

--- a/KeKi/Scenes/Feed/FeedViewController.swift
+++ b/KeKi/Scenes/Feed/FeedViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 class FeedViewController: UIViewController {
     // MARK: - Variables, IBOutlet, ...
     var postIdx: Int = -1
-    var mode: FeedMode?
     var feedData: [Feed] = []
     
     @IBOutlet weak var tableView: UITableView!
@@ -28,9 +27,6 @@ class FeedViewController: UIViewController {
 
     
     // MARK: - Helper Methods (Setup Method, ...)
-    func setData(postIdx: Int) {
-        fetchData()
-    }
     
     private func fetchData() {
         if postIdx != -1 {
@@ -48,6 +44,7 @@ class FeedViewController: UIViewController {
     }
     
     private func setupNavigationBar() {
+        navigationController?.navigationBar.tintColor = .black
         navigationController?.navigationBar.isHidden = false
         navigationItem.title = "피드"
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.backward"), style: .plain, target: self, action: #selector(didTapBackItem))

--- a/KeKi/Scenes/Feed/FeedViewController.swift
+++ b/KeKi/Scenes/Feed/FeedViewController.swift
@@ -9,15 +9,16 @@ import UIKit
 
 class FeedViewController: UIViewController {
     // MARK: - Variables, IBOutlet, ...
-    var postIdx: Int = -1   // 피드 개별 조회할 경우, postIdx 값이 변경 -> API 호출 다르게 하도록
-    private var feedData: [Feed] = []
+    var postIdx: Int = -1
+    var mode: FeedMode?
+    var feedData: [Feed] = []
     
     @IBOutlet weak var tableView: UITableView!
     
     // MARK: - Methods of LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        fetchData()
+        if feedData.count == 0 { fetchData() }
         
         setupNavigationBar()
         setupTableView()
@@ -43,9 +44,6 @@ class FeedViewController: UIViewController {
                 self?.tableView.reloadData()
                 
             })
-        }
-        else {
-            // TODO: 피드 목록 조회 (by 스토어명 / 검색어 / 태그명)
         }
     }
     

--- a/KeKi/Scenes/Feed/FeedViewController.swift
+++ b/KeKi/Scenes/Feed/FeedViewController.swift
@@ -27,10 +27,9 @@ class FeedViewController: UIViewController {
 
     
     // MARK: - Helper Methods (Setup Method, ...)
-    
     private func fetchData() {
+        // 개별 피드 조회
         if postIdx != -1 {
-            // 개별 피드 조회
             APIManeger.shared.testGetData(urlEndpointString: "/posts/\(postIdx)",
                                           dataType: SingleFeedResponse.self,
                                           parameter: nil,

--- a/KeKi/Scenes/Home/HomeCollectionViewCell.swift
+++ b/KeKi/Scenes/Home/HomeCollectionViewCell.swift
@@ -30,6 +30,6 @@ class HomeCollectionViewCell: UICollectionViewCell {
     
     func setData(storeData: HomePostRes) {
         storeImageView.kf.setImage(with: URL(string: storeData.postImgUrl))
-//        storeNameLabel.text = storeData.storeTitle
+        storeNameLabel.text = storeData.storeTitle
     }
 }

--- a/KeKi/Scenes/Home/HomeTableViewCell.swift
+++ b/KeKi/Scenes/Home/HomeTableViewCell.swift
@@ -81,7 +81,31 @@ extension HomeTableViewCell: UICollectionViewDataSource {
 
 extension HomeTableViewCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // TODO: 각 태그별 스토어 게시물 탭 이벤트 처리 메소드 정의 필요
         print("tapped store post :: indexPath --> \(indexPath)")
+        
+        // TODO: 각 태그별 스토어 게시물 탭 이벤트 처리 메소드 정의 필요
+        // 탭 이벤트가 발생한 게시물의 인덱스 정보 (postIdx)를 피드 상세를 보여주는 셀에 넘겨주고
+        // 피드 상세 셀에서 받은 postIdx를 통해 서버에서 피드 정보 불러오기
+        
+        let storyboard = UIStoryboard.init(name: "Feed", bundle: nil)
+        guard let feedViewController = storyboard.instantiateViewController(withIdentifier: "FeedViewController") as? FeedViewController else { return }
+        
+        feedViewController.postIdx = storePostList[indexPath.row].postIdx
+        
+        if let vc = self.next(ofType: UIViewController.self) {
+            vc.tabBarController?.tabBar.isHidden = true
+            vc.navigationController?.pushViewController(feedViewController, animated: true)
+        }
+    }
+}
+
+extension UIResponder {
+    func next<T:UIResponder>(ofType: T.Type) -> T? {
+        let r = self.next
+        if let r = r as? T ?? r?.next(ofType: T.self) {
+            return r
+        } else {
+            return nil
+        }
     }
 }

--- a/KeKi/Scenes/Home/HomeViewController.swift
+++ b/KeKi/Scenes/Home/HomeViewController.swift
@@ -135,8 +135,14 @@ extension HomeViewController: TagDetailDelegate {
         let storyboard = UIStoryboard.init(name: "Search", bundle: nil)
         guard let searchResultViewController = storyboard.instantiateViewController(withIdentifier: "SearchViewController") as? SearchViewController else { return }
 
+        let tag = tagTitle.trimmingCharacters(in: ["#"," "])
+        searchResultViewController.search(searchText: nil,
+                                          hashTag: tag,
+                                          sortType: SortType.Recent.rawValue,
+                                          cursorIdx: nil,
+                                          cursorPopularNum: nil,
+                                          cursorPrice: nil)
+        searchResultViewController.setSearchText(text: tag)
         self.navigationController?.pushViewController(searchResultViewController, animated: true)
-        
-        // TODO: 탭 액션이 발생한 태그의 검색 결과 화면으로 전환 (현재 검색 화면까지만 넘어가도록 구현)
     }
 }

--- a/KeKi/Scenes/Home/HomeViewController.swift
+++ b/KeKi/Scenes/Home/HomeViewController.swift
@@ -33,15 +33,13 @@ class HomeViewController: UIViewController {
         super.viewDidLoad()
 
         fetchData()
-        
-        navigationController?.navigationBar.isHidden = true
-        tabBarController?.tabBar.isHidden = false
         setUpDdayCountingLabel()
-        
         setupTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        navigationController?.navigationBar.isHidden = true
+        tabBarController?.tabBar.isHidden = false
         tabBarController?.selectedIndex = 0
     }
     

--- a/KeKi/Scenes/Search/SearchViewController.swift
+++ b/KeKi/Scenes/Search/SearchViewController.swift
@@ -103,6 +103,11 @@ class SearchViewController: UIViewController {
         fetchSearchMain()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.navigationBar.isHidden = true
+    }
+        
     func setup() {
         searchTextField.delegate = self
         searchTextField.text = searchText ?? ""
@@ -349,7 +354,10 @@ extension SearchViewController: UICollectionViewDelegate, UICollectionViewDataSo
         }else if collectionView.tag == 3 {
            
         }else {
-           
+            let storyboard = UIStoryboard.init(name: "Feed", bundle: nil)
+            guard let feedViewController = storyboard.instantiateViewController(withIdentifier: "FeedViewController") as? FeedViewController else { return }
+            feedViewController.feedData = searchResultList
+            self.navigationController?.pushViewController(feedViewController, animated: true)
         }
     }
     
@@ -405,16 +413,28 @@ extension SearchViewController {
 extension SearchViewController {
     func fetchSearchMain() {
         // MARK: 로그인 토큰 있을 시 검색 메인 화면
-        APIManeger.shared.getData(urlEndpointString: "/histories", dataType: SearchMainResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
-            
+//        APIManeger.shared.getData(urlEndpointString: "/histories", dataType: SearchMainResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
+//
+//            self?.recentTextList = response.result.recentSearches
+//            self?.popularTextList = response.result.popularSearches
+//            self?.recentCakeList = response.result.recentPostSearches
+//
+//            self?.recentCV.reloadData()
+//            self?.popularCV.reloadData()
+//            self?.recentCakeCV.reloadData()
+//        }
+        APIManeger.shared.testGetData(urlEndpointString: "/histories",
+                                      dataType: SearchMainResponse.self,
+                                      parameter: nil,
+                                      completionHandler: { [weak self] response in
             self?.recentTextList = response.result.recentSearches
             self?.popularTextList = response.result.popularSearches
             self?.recentCakeList = response.result.recentPostSearches
-            
+
             self?.recentCV.reloadData()
             self?.popularCV.reloadData()
             self?.recentCakeCV.reloadData()
-        }
+        })
         
         // MARK: 로그인 토큰 없을 시 검색 메인 화면
 //        APIManeger.shared.getData(urlEndpointString: "/histories", dataType: NoLoginSearchMainResponse.self, header: nil) { [weak self] response in
@@ -426,19 +446,33 @@ extension SearchViewController {
     
     // MARK: 최근 검색어 - GET
     func fetchRecnetSearches() {
-        APIManeger.shared.getData(urlEndpointString: "/histories/recent-searches", dataType: RecentSearchesResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
+//        APIManeger.shared.getData(urlEndpointString: "/histories/recent-searches", dataType: RecentSearchesResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
+//            self?.recentTextList = response.result
+//            self?.recentCV.reloadData()
+//        }
+        APIManeger.shared.testGetData(urlEndpointString: "/histories/recent-searches",
+                                      dataType: RecentSearchesResponse.self,
+                                      parameter: nil, completionHandler: { [weak self] response in
             self?.recentTextList = response.result
             self?.recentCV.reloadData()
-        }
+        })
     }
     
     // MARK: 최근 검색어 삭제 - PATCH
     func deleteRecentSearches() {
-        APIManeger.shared.patchData(urlEndpointString: "/histories", dataType: SearchMainResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
-            if response.isSuccess == true {
-                self?.fetchRecnetSearches()
-            }
-        }
+//        APIManeger.shared.patchData(urlEndpointString: "/histories", dataType: SearchMainResponse.self, header: APIManeger.buyerTokenHeader, parameter: nil) { [weak self] response in
+//            if response.isSuccess == true {
+//                self?.fetchRecnetSearches()
+//            }
+//        }
+        APIManeger.shared.testPatchData(urlEndpointString: "/histories",
+                                        dataType: SearchMainResponse.self,
+                                        parameter: nil,
+                                        completionHandler: { [weak self] response in
+                    if response.isSuccess == true {
+                        self?.fetchRecnetSearches()
+                    }
+        })
     }
     
     // MARK: 검색 파라미터 만든 후 검색
@@ -459,15 +493,39 @@ extension SearchViewController {
     
     // MARK: 검색 - GET
     func fetchSearchResult(queryParam: Parameters) {
-        APIManeger.shared.getData(urlEndpointString: "/posts", dataType: SearchResultResponse.self, header: APIManeger.buyerTokenHeader, parameter: queryParam) { [weak self] response in
+//        APIManeger.shared.getData(urlEndpointString: "/posts", dataType: SearchResultResponse.self, header: APIManeger.buyerTokenHeader, parameter: queryParam) { [weak self] response in
+//            if response.result.feeds?.count != 0 {
+//                response.result.feeds?.forEach({ feed in
+//                    self?.searchResultList.append(feed)
+//                })
+//
+//                self?.cursorIdx = response.result.cursorIdx
+//                self?.hasNext = response.result.hasNext
+//
+//                if self?.sortType == .Popular {
+//                    self?.cursorPopularNum = response.result.cursorPopularNum
+//                }else if self?.sortType == .LowPrice {
+//                    self?.cursorPrice = response.result.cursorPrice
+//                }
+//                self?.showResultView()
+//            }else {
+//                self?.showNoResultView()
+//            }
+//
+//            self?.isLoading = false
+//        }
+        
+        APIManeger.shared.testGetData(urlEndpointString: "/posts",
+                                      dataType: SearchResultResponse.self,
+                                      parameter: queryParam, completionHandler: { [weak self] response in
             if response.result.feeds?.count != 0 {
                 response.result.feeds?.forEach({ feed in
                     self?.searchResultList.append(feed)
                 })
-                
+
                 self?.cursorIdx = response.result.cursorIdx
                 self?.hasNext = response.result.hasNext
-                
+
                 if self?.sortType == .Popular {
                     self?.cursorPopularNum = response.result.cursorPopularNum
                 }else if self?.sortType == .LowPrice {
@@ -477,9 +535,9 @@ extension SearchViewController {
             }else {
                 self?.showNoResultView()
             }
-            
+
             self?.isLoading = false
-        }
+        })
         
         
     }

--- a/KeKi/Scenes/Search/SearchViewController.swift
+++ b/KeKi/Scenes/Search/SearchViewController.swift
@@ -105,6 +105,7 @@ class SearchViewController: UIViewController {
     
     func setup() {
         searchTextField.delegate = self
+        searchTextField.text = searchText ?? ""
         
         var tag = 1
         
@@ -157,6 +158,10 @@ class SearchViewController: UIViewController {
         
         self.sortTypeButtonViewHeight.priority = UILayoutPriority(1000)
         sortTypeButtonView.layer.masksToBounds = false
+    }
+    
+    func setSearchText(text: String) {
+        self.searchText = text
     }
     
     func setHideButtonTitle() {


### PR DESCRIPTION
## 📚 이슈 번호
#46 

## 💬 기타 사항
- 토큰 만료 및 로그아웃 이슈로 부득이하게 searchVC에 있는 API 관련 메소드를 재정의 메소드(testGetData, testPatchData, ...)로 변경해두었습니다
- 이전에 작성해주신 API 관련 메소드들(getData, patchData, ...)은 주석 처리 해두었습니다 
  (아래 작성된 것과 같이 필요에 따라, 주석처리를 통해 메소드를 달리 써주시면 됩니다)
- 앞으로 실행해보실 때, 

-       카톡 회원가입 및 로그인 후에 실행하신다면 --> 지금 추가되어있는 재정의 메소드
-       서버 측에서 올려준 토큰 값을 사용하신다면 --> 주석처리 되어있는 기존의 메소드

   를 사용해주시면 됩니당,,!

**_DONE_**
- 피드 상세 화면 서버 연동
- (홈 화면) 썸네일 하나 탭 -> 단일 피드 상세 화면
- (홈 화면) 태그 더보기 탭 -> 검색 결과 화면 -> 썸네일 하나 탭 -> 피드 목록 조회 화면 (쿼리 파라미터에는 태그 정보)
- (검색 화면) 키워드를 통한 검색 결과 화면 -> 썸네일 하나 탭 -> 피드 목록 조회 화면 (쿼리 파라미터에는 검색 키워드 정보)

**_TODO_**
- 피드 목록 조회 화면으로 넘어갔을 때, 탭 이벤트가 일어난 피드가 화면 중심에 오도록 indexing 수정 필요
- 피드 찜/찜취소 기능
- 피드 신고 기능
- 피드 제목 탭 -> 해당 피드의 상품 상세 화면으로 전환