### PR TITLE
fix: 피드 옵션 수정 (신고하기만 놔두고 모두 삭제)

### DIFF
--- a/KeKi/Scenes/Feed/FeedViewController.swift
+++ b/KeKi/Scenes/Feed/FeedViewController.swift
@@ -119,27 +119,13 @@ extension FeedViewController: FeedDelegate {
     
     func showFeedMainAlert() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        
         let declarationAction = UIAlertAction(title: "신고하기", style: .default) { [weak self] _ in
             self?.showFeedDeclarationActionAlert()
         }
-        
-        let notToSeeAction = UIAlertAction(title: "게시글 보지 않기", style: .default) {_ in
-            // TODO: 게시글 안 보이게 하는 기능 구현
-        }
-        
-        let blockAction = UIAlertAction(title: "차단하기", style: .default) {_ in
-            // TODO: 피드 게시자 차단 기능 구현
-        }
-        
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         
-        [
-            declarationAction,
-            notToSeeAction,
-            blockAction,
-            cancelAction
-        ].forEach { alert.addAction($0) }
+        alert.addAction(declarationAction)
+        alert.addAction(cancelAction)
         present(alert, animated: true)
     }
     


### PR DESCRIPTION
## 📚 이슈 번호
#13 

## 💬 기타 사항
- 게시글 보지 않기 / 차단하기 옵션 제외했움다
